### PR TITLE
Fix stray quote in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ nodeEmailCleanupTool
 ## Script Descriptions
 
 1. **`assignLabel.mjs`**:
-   - Assigns a "to be deleted" label to emails based on a list of senders provided in a Google Sheet"for easy filter delete.
+   - Assigns a "to be deleted" label to emails based on a list of senders provided in a Google Sheet for easy filter delete.
 
 2. **`emailAnalysis.mjs`**:
    - Analyzes your inbox to count emails from different senders and updates a Google Sheet with the results.


### PR DESCRIPTION
## Summary
- remove stray quote in script description for `assignLabel.mjs`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d2146e5b88330b9de6f77e1970f41