### PR TITLE
Fix infinite loop in email fetch

### DIFF
--- a/Functions/emailAnalysis.mjs
+++ b/Functions/emailAnalysis.mjs
@@ -52,6 +52,11 @@ async function fetchEmails(auth) {
             const messages = res.data.messages || [];
             pageToken = res.data.nextPageToken;
 
+            if (messages.length === 0) {
+                console.warn('No messages returned from API, stopping early to prevent infinite loop.');
+                break;
+            }
+
             const batchSize = Math.min(messages.length, totalEmails - fetchedEmails);
             fetchedEmails += batchSize;
 


### PR DESCRIPTION
## Summary
- stop emailAnalysis from running endlessly when Gmail API returns an empty page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d200225248330943d979935334759